### PR TITLE
Common potential function for delete and insert

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,96 +6,9 @@ We show via the LiquidHaskell framework that my functional Implementation of the
 ## Potential Analysis for Complexity 
 We prove automatically the theorems regarding the complexity of weak AVL trees first proven by hand in {Haeupler, 2015 #48}. 
 
-# Watch out for's of LiquidHaskell
-
-## function annotation
-
-in a function annotation we can use the input to refine the output, and vice versa. Like this: 
-
-```haskell
-{-@ merge :: x:a -> l:Wavl -> r:Wavl -> {v:Rank | WavlRankN v l r }  -> t:Wavl @-}
-```
-
-But LiquidHaskell will not accept the following and throws an unbound Sort Refinement Error: 
-```haskell
-{-@ merge :: x:a -> {v:Rank | WavlRankN v l r } -> l:Wavl -> r:Wavl -> t:Wavl @-}
-```
-This is a LiquidHaskell implementation detail. In a function refinement, if you use a variable like l or r before declaration, it will not be accepted. 
-
-## Special cases because of LiquidHaskell
-
-To show correctness of the insert algorithm with LiquidHaskell I had to make some implicit logical knowledge over the structure explicit. 
-E.g. the pattern matching case for the rebalancing in the insert function could look like this: 
-
-```haskell
-insert x t@(Tree v n l r) = case compare x v of
-    LT -> insL
-    GT -> insR
-    EQ -> t
-    where 
-        l' = insert x l
-        lt' = Tree v n l' r
-        insL | rk l' < n = lt'
-             | rk l' == rk r + 1 = promoteL lt'
-             | (rk (left l') + 1) == rk l' = rotateRight lt' 
-             | otherwise = rotateDoubleRight lt' 
-```
-
-but because we need to make sure that the input to the functions of rotateRight / rotateDoubleRight is "filtered", i.e. the logical condition is used to show that this branch only gives over the correct refined lt', so that it satisfies their type annotations. 
-
-```haskell
-insert x t@(Tree v n l r) = case compare x v of
-    LT -> insL
-    GT -> insR
-    EQ -> t
-    where 
-        l' = insert x l
-        lt' = Tree v n l' r
-        insL | rk l' < n = lt'
-             | rk l' == n && rk l' == rk r + 1 = promoteL lt'
-             | rk l' == n && rk l' == rk r + 2 && (rk (left l') + 1) == rk l' && (rk (right l') + 2) == rk l' && notEmptyTree (left l') = rotateRight lt' 
-             | rk l' == n && rk l' == rk r + 2 && (rk (right l') + 1) == rk l' && (rk (left l') + 2) == rk l' && notEmptyTree (right l') = rotateDoubleRight lt' 
-             | otherwise = t
-...
-```
-
-with our (implicit) knowledge over the data structure we know that the otherwise case will never execute. this is because the input to insert will always be a legitimate wAVL tree, which is defined via the balanced condition: 
-
-```haskell
-{-@ type Wavl = {v: Tree a | balanced v} @-}
-
-{-@ measure balanced @-}
-balanced :: Tree a -> Bool
-balanced Nil = True
-balanced t@(Tree _ n l r) = rk r < n && n <= rk r + 2 
-                         && rk l < n && n <= rk l + 2
-                         && (balanced l)
-                         && (balanced r)
-```
-
-Therefore, we know that a tree under insertion will sat. these conditions beforehand. During the insertion there can be only one violation of this, namely that there is a Node with a 0-child, i.e. a 0,1-Node or a 0,2-Node respectively. These two cases are pattern matched, while 0,2-Nodes are further checked whether the right or left child node of l' (or respectively r' in mirror case insR) fulfills the condition of being the one node where the further down insertion took place. 
-
-Also, LH cannot infer that another case will not be accessed, namely what happens if we encounter a 0,2-Node with a left child, which is a 1,1-Node?
-Well, this cannot happen. Since via the insertion we could create a single 0-Child, this will stay the only violation in the data structure. The violation is then being moved up via a promote step, leaving a 1,2-Node behind. So in order for an execution of rotate* or doubleRotate* we know that the structure of the underlying tree must have been created by 1 or more promote steps. Nothing else would create a violation of the balanced constraint and we would only return the new tree as a result of the first pattern in insL. 
-
-Thus, we know that l' must be either a 1,2-Node or 2,1-Node, because a 1,1-Node couldn't be produced by a previous promote step. If a 1,1-Node was created through the insertion, the said Node would have to been either a 1,2-Node, and promotion would make the 2-child to a 1-child. But this would not change the rank of the bespoken node itself and thus the rank violation is corrected. 
-
-the last case of l' being a 2,2-node can be disregarded since then the node would have been a 2,3-Node before the insertion, which is not possible since we only insert into balanced wAVL trees. 
-
-thus, our pattern matching cases are legit but LH cannot infer this on it's own. 
-
-A last notion: the `otherwise` case will also not be executed but is needed to tell LH that all patterns are matched. To prove that this case is never executed we just need to look again at the insertion path and in what states a node could be in along this path. 
-
-Either a rank violation in form of a 0-child is carried along and the first pattern does not match. In that case, one of the other three cases will definitely execute as shown above. Otherwise, the first pattern will match since after a "terminal" rotation or promotion step the tree will be balanced totally, since there will always only be one violation be introduced via insertion and carried upwards along the insertion path. 
-
-Thus, we have shown that every possible case in the recursion is matched and the otherwise operation will not execute. 
-
-## Refinement reflection
-
-I had the case, when I did some tests on how to add the potential function `potT` and `pot2` to the function refinement of the rotation, I originally planned to use the reflected functions (via `{-@ LIQUID "--reflection" @-}`) in some form of proof. Later, I was able to forego these sorts of proof and didn't need to reflect my functions to the logic. 
-
-At this point I removed the `{-@ reflect myFunc @-}` annotations and I thought that the file would still compile but that wasn't the case. After some trials I found that 
-reflecting `singleton` into the logic helped checking the refinement of two of my rotate cases (`rotateRightD` and `rotateLeftD`). without singleton, the following expression could not be checked: `(potT2 t' + tcost t - tcost s) == potT2 (tval s)`
+# merged potential annotation for insert and delete
+We redefined the used potential function in Haeupler et. al such that the previously separately proven potential is now combined: 
+> "Das Potential von 2,2 und 2,3 nodes ist 2, das Potential von 1,1 und 0,1 nodes ist 1, das Potential von allen anderen nodes ist 0."
 
 # References
 Haeupler, B., et al. (2015). "Rank-Balanced Trees." ACM Transactions on Algorithms 11(4): 1-26.

--- a/docs/watch out fors_LH.md
+++ b/docs/watch out fors_LH.md
@@ -1,0 +1,90 @@
+# Watch out for's of LiquidHaskell
+
+## function annotation
+
+in a function annotation we can use the input to refine the output, and vice versa. Like this: 
+
+```haskell
+{-@ merge :: x:a -> l:Wavl -> r:Wavl -> {v:Rank | WavlRankN v l r }  -> t:Wavl @-}
+```
+
+But LiquidHaskell will not accept the following and throws an unbound Sort Refinement Error: 
+```haskell
+{-@ merge :: x:a -> {v:Rank | WavlRankN v l r } -> l:Wavl -> r:Wavl -> t:Wavl @-}
+```
+This is a LiquidHaskell implementation detail. In a function refinement, if you use a variable like l or r before declaration, it will not be accepted. 
+
+## Special cases because of LiquidHaskell
+
+To show correctness of the insert algorithm with LiquidHaskell I had to make some implicit logical knowledge over the structure explicit. 
+E.g. the pattern matching case for the rebalancing in the insert function could look like this: 
+
+```haskell
+insert x t@(Tree v n l r) = case compare x v of
+    LT -> insL
+    GT -> insR
+    EQ -> t
+    where 
+        l' = insert x l
+        lt' = Tree v n l' r
+        insL | rk l' < n = lt'
+             | rk l' == rk r + 1 = promoteL lt'
+             | (rk (left l') + 1) == rk l' = rotateRight lt' 
+             | otherwise = rotateDoubleRight lt' 
+```
+
+but because we need to make sure that the input to the functions of rotateRight / rotateDoubleRight is "filtered", i.e. the logical condition is used to show that this branch only gives over the correct refined lt', so that it satisfies their type annotations. 
+
+```haskell
+insert x t@(Tree v n l r) = case compare x v of
+    LT -> insL
+    GT -> insR
+    EQ -> t
+    where 
+        l' = insert x l
+        lt' = Tree v n l' r
+        insL | rk l' < n = lt'
+             | rk l' == n && rk l' == rk r + 1 = promoteL lt'
+             | rk l' == n && rk l' == rk r + 2 && (rk (left l') + 1) == rk l' && (rk (right l') + 2) == rk l' && notEmptyTree (left l') = rotateRight lt' 
+             | rk l' == n && rk l' == rk r + 2 && (rk (right l') + 1) == rk l' && (rk (left l') + 2) == rk l' && notEmptyTree (right l') = rotateDoubleRight lt' 
+             | otherwise = t
+...
+```
+
+with our (implicit) knowledge over the data structure we know that the otherwise case will never execute. this is because the input to insert will always be a legitimate wAVL tree, which is defined via the balanced condition: 
+
+```haskell
+{-@ type Wavl = {v: Tree a | balanced v} @-}
+
+{-@ measure balanced @-}
+balanced :: Tree a -> Bool
+balanced Nil = True
+balanced t@(Tree _ n l r) = rk r < n && n <= rk r + 2 
+                         && rk l < n && n <= rk l + 2
+                         && (balanced l)
+                         && (balanced r)
+```
+
+Therefore, we know that a tree under insertion will sat. these conditions beforehand. During the insertion there can be only one violation of this, namely that there is a Node with a 0-child, i.e. a 0,1-Node or a 0,2-Node respectively. These two cases are pattern matched, while 0,2-Nodes are further checked whether the right or left child node of l' (or respectively r' in mirror case insR) fulfills the condition of being the one node where the further down insertion took place. 
+
+Also, LH cannot infer that another case will not be accessed, namely what happens if we encounter a 0,2-Node with a left child, which is a 1,1-Node?
+Well, this cannot happen. Since via the insertion we could create a single 0-Child, this will stay the only violation in the data structure. The violation is then being moved up via a promote step, leaving a 1,2-Node behind. So in order for an execution of rotate* or doubleRotate* we know that the structure of the underlying tree must have been created by 1 or more promote steps. Nothing else would create a violation of the balanced constraint and we would only return the new tree as a result of the first pattern in insL. 
+
+Thus, we know that l' must be either a 1,2-Node or 2,1-Node, because a 1,1-Node couldn't be produced by a previous promote step. If a 1,1-Node was created through the insertion, the said Node would have to been either a 1,2-Node, and promotion would make the 2-child to a 1-child. But this would not change the rank of the bespoken node itself and thus the rank violation is corrected. 
+
+the last case of l' being a 2,2-node can be disregarded since then the node would have been a 2,3-Node before the insertion, which is not possible since we only insert into balanced wAVL trees. 
+
+thus, our pattern matching cases are legit but LH cannot infer this on it's own. 
+
+A last notion: the `otherwise` case will also not be executed but is needed to tell LH that all patterns are matched. To prove that this case is never executed we just need to look again at the insertion path and in what states a node could be in along this path. 
+
+Either a rank violation in form of a 0-child is carried along and the first pattern does not match. In that case, one of the other three cases will definitely execute as shown above. Otherwise, the first pattern will match since after a "terminal" rotation or promotion step the tree will be balanced totally, since there will always only be one violation be introduced via insertion and carried upwards along the insertion path. 
+
+Thus, we have shown that every possible case in the recursion is matched and the otherwise operation will not execute. 
+
+## Refinement reflection
+
+I had the case, when I did some tests on how to add the potential function `potT` and `pot2` to the function refinement of the rotation, I originally planned to use the reflected functions (via `{-@ LIQUID "--reflection" @-}`) in some form of proof. Later, I was able to forego these sorts of proof and didn't need to reflect my functions to the logic. 
+
+At this point I removed the `{-@ reflect myFunc @-}` annotations and I thought that the file would still compile but that wasn't the case. After some trials I found that 
+reflecting `singleton` into the logic helped checking the refinement of two of my rotate cases (`rotateRightD` and `rotateLeftD`). without singleton, the following expression could not be checked: `(potT2 t' + tcost t - tcost s) == potT2 (tval s)`

--- a/lhTest.cabal
+++ b/lhTest.cabal
@@ -22,7 +22,7 @@ library
   exposed-modules:
     --   WAVL_With_Rankdiff,     
     --   AVL,
-      WAVL,
+      -- WAVL,
       PotentialAnalysis_WAVL
       -- BinomialHeap
     -- PopPush

--- a/src/PotentialAnalysis_WAVL.hs
+++ b/src/PotentialAnalysis_WAVL.hs
@@ -348,7 +348,7 @@ if case
 {-@ balLDel :: x:a -> n:NodeRank -> {l:Tick ({l':Wavl | Is3ChildN n l'}) | tcost l >= 0 } -> {r':MaybeWavlNode | Is2ChildN n r'} 
           -> {t:Tick ({t':NEWavl | (rk t' == n || rk t' + 1 == n) 
           && (
-            (potT2 t' + 1 <= potT2 (Tree x n (tval l) r') + 4) 
+            ((potT2 t' + 1 <= potT2 (Tree x n (tval l) r') + 4) && (balanced t')) 
           || (potT t'  + 1 <= potT2 (Tree x n (tval l) r') + 4)) 
           })| tcost t >= 0 } @-}
 balLDel :: a -> Int -> Tick (Tree a) -> Tree a -> Tick (Tree a)

--- a/src/WAVL.hs
+++ b/src/WAVL.hs
@@ -1,12 +1,9 @@
 {-@ LIQUID "--short-names" @-}
 {-@ LIQUID "--reflection" @-}
 {-@ LIQUID "--ple" @-}
-{-@ LIQUID "--bscope" @-}
 
 module WAVL (Tree (..), singleton,
- insert, 
---  delete,
-  rk, 
+ insert, delete, rk, 
  promoteL, promoteR, 
  demoteL, demoteR, doubleDemoteL, doubleDemoteR, 
  rotateRight, rotateLeft,
@@ -15,19 +12,12 @@ module WAVL (Tree (..), singleton,
  rotateLeftD, rotateRightD,  
  rotateDoubleLeftD, 
  rotateDoubleRightD, 
- notEmptyTree, empty,
- potT, potT2
+ notEmptyTree, empty
  ) where
 
 import Language.Haskell.Liquid.ProofCombinators
-import Language.Haskell.Liquid.RTick as RTick
-import Prelude hiding (pure)
 
 {-@ reflect singleton @-}
-{-@ reflect rotateDoubleLeftD @-}
-{-@ reflect rotateDoubleRightD @-}
-{-@ reflect rotateRightD @-}
-{-@ reflect rotateLeftD @-}
 {-@ reflect nil @-}
 
 -- Basic functions
@@ -99,25 +89,6 @@ isWavlNode t@(Tree x n l r) =  ((rk l) + 2 == n && (rk r) + 2 == n && notEmptyTr
 {-@ singleton :: a -> {v:NEWavl | ht v == 0 && rk v == 0 } @-}
 singleton a = Tree a 0 Nil Nil
 
--- potential analysis for deletion and insertion
-{-@ measure potT @-}
-{-@ potT :: t:Wavl -> Int @-}
-potT :: Tree a -> Int
-potT Nil      = 0
-potT t@(Tree _ n l r) 
-  | rk l == rk r && rk l + 1 == n = 1 + potT l + potT r        -- 1,1-Node
-  | otherwise = potT l + potT r                                -- 2,*-Nodes
-
-{-@ measure potT2 @-}
-{-@ potT2 :: t:AlmostWavl -> Int @-}
-potT2 :: Tree a -> Int 
-potT2 t@Nil = 0
-potT2 t@(Tree _ n l r)
-  | rk l == n && rk r + 1 == n     = 1 + potT l + potT r    -- 0,1-Node
-  | rk r == n && rk l + 1 == n     = 1 + potT l + potT r    -- 1,0-Node
-  | rk r + 1 == n && rk l + 1 == n = 1 + potT l + potT r    -- 1,1-Node
-  | otherwise = potT l + potT r
-
 -- insertion
 {-@ insert :: (Ord a) => a -> s:Wavl -> {t:NEWavl | ((RkDiff t s 1) || (RkDiff t s 0)) } @-}
 insert :: (Ord a) => a -> Tree a -> Tree a
@@ -142,28 +113,27 @@ insert x t@(Tree v n l r) = case compare x v of
              | rk r' == n && rk r' == rk l + 2 && (rk (left r') + 1) == rk r' && (rk (right r') + 2) == rk r' && n >= 1 = rotateDoubleLeft rt'
              | otherwise = t
 
-{-@ promoteL :: s:Node0_1 -> {t:Node1_2 | RkDiff t s 1 && potT2 s == potT t + 1} @-}
+{-@ promoteL :: s:Node0_1 -> {t:Node1_2 | RkDiff t s 1 } @-}
 promoteL :: Tree a -> Tree a
 promoteL (Tree a n l r) = (Tree a (n+1) l r)
 
-{-@ promoteR :: s:Node1_0 -> {t:NEWavl | RkDiff t s 1 && potT2 s == potT t + 1 } @-}
+{-@ promoteR :: s:Node1_0 -> {t:NEWavl | RkDiff t s 1} @-}
 promoteR :: Tree a -> Tree a
 promoteR (Tree a n l r) = (Tree a (n+1) l r)
 
-{-@ rotateRight :: {v:Node0_2 | IsNode1_2 (left v) } -> {t:NEWavl | EqRk v t && potT2 v + 2 == potT t} @-}
+{-@ rotateRight :: {v:Node0_2 | IsNode1_2 (left v) } -> {t:NEWavl | EqRk v t } @-}
 rotateRight :: Tree a -> Tree a
 rotateRight (Tree x n (Tree y m a b) c) = Tree y m a (Tree x (n-1) b c)
 
-{-@ rotateDoubleRight :: {v:Node0_2 | IsNode2_1 (left v) } -> {t:NEWavl | EqRk v t && (potT2 v + 2 == potT t || potT2 v + 1 == potT t)} @-}
+{-@ rotateDoubleRight :: {v:Node0_2 | IsNode2_1 (left v) } -> {t:NEWavl | EqRk v t } @-}
 rotateDoubleRight :: Tree a -> Tree a 
 rotateDoubleRight (Tree z n (Tree x m a (Tree y o b c)) d) =  Tree y (o+1) (Tree x (m-1) a b) (Tree z (n-1) c d) 
 
-{-@ rotateLeft :: {v:Node2_0 | IsNode2_1 (right v) } -> {t:NEWavl | EqRk v t && potT2 v + 2 == potT t} @-}
+{-@ rotateLeft :: {v:Node2_0 | IsNode2_1 (right v) } -> {t:NEWavl | EqRk v t } @-}
 rotateLeft :: Tree a -> Tree a
 rotateLeft t@(Tree x n a (Tree y m b c)) = Tree y m (Tree x (n-1) a b) c
 
-{-@ rotateDoubleLeft :: {v:Node2_0 | IsNode1_2 (right v) } 
-          -> {t:NEWavl | EqRk v t && (potT2 v + 2 == potT t || potT2 v + 1 == potT t)} @-}
+{-@ rotateDoubleLeft :: {v:Node2_0 | IsNode1_2 (right v) } -> {t:NEWavl | EqRk v t } @-}
 rotateDoubleLeft :: Tree a -> Tree a
 rotateDoubleLeft (Tree x n a (Tree y m (Tree z o b_1 b_2) c)) = Tree z (o+1) (Tree x (n-1) a b_1) (Tree y (m-1) b_2 c) 
 
@@ -230,125 +200,140 @@ rotateDoubleLeft (Tree x n a (Tree y m (Tree z o b_1 b_2) c)) = Tree z (o+1) (Tr
 --       r' = delete x r
       
 -- Deletion functions, but with cases for Tree expanded
--- {-@ delete :: (Ord a) => a -> s:Wavl -> {t:Wavl | (EqRk s t) || (RkDiff s t 1)} @-}
--- delete _ Nil = nil
--- delete y (Tree x n l@Nil r@Nil)
---   | y < x     = balLDel x n l' r
---   | x < y     = balRDel x n l r'
---   | otherwise = merge y l r n 
---     where
---       l' = delete x l
---       r' = delete x r
--- delete y (Tree x n l@Nil r@(Tree _ _ _ _))
---   | y < x     = balLDel x n l' r
---   | x < y     = balRDel x n l r'
---   | otherwise = merge y l r n 
---     where
---       l' = delete x l
---       r' = delete x r
--- delete y (Tree x n l@(Tree _ _ _ _) r@Nil)
---   | y < x     = balLDel x n l' r
---   | x < y     = balRDel x n l r'
---   | otherwise = merge y l r n 
---     where
---       l' = delete x l
---       r' = delete x r
--- delete y (Tree x n l@(Tree _ _ _ _) r@(Tree _ _ _ _))
---   | y < x     = balLDel x n l' r
---   | x < y     = balRDel x n l r'
---   | otherwise = merge y l r n 
---     where
---       l' = delete x l
---       r' = delete x r
+{-@ delete :: (Ord a) => a -> s:Wavl -> {t:Wavl | (EqRk s t) || (RkDiff s t 1)} @-}
+delete _ Nil = nil
+delete y (Tree x n l@Nil r@Nil)
+  | y < x     = balLDel x n l' r
+  | x < y     = balRDel x n l r'
+  | otherwise = merge y l r n 
+    where
+      l' = delete x l
+      r' = delete x r
+delete y (Tree x n l@Nil r@(Tree _ _ _ _))
+  | y < x     = balLDel x n l' r
+  | x < y     = balRDel x n l r'
+  | otherwise = merge y l r n 
+    where
+      l' = delete x l
+      r' = delete x r
+delete y (Tree x n l@(Tree _ _ _ _) r@Nil)
+  | y < x     = balLDel x n l' r
+  | x < y     = balRDel x n l r'
+  | otherwise = merge y l r n 
+    where
+      l' = delete x l
+      r' = delete x r
+delete y (Tree x n l@(Tree _ _ _ _) r@(Tree _ _ _ _))
+  | y < x     = balLDel x n l' r
+  | x < y     = balRDel x n l r'
+  | otherwise = merge y l r n 
+    where
+      l' = delete x l
+      r' = delete x r
 
--- {-@ merge :: x:a -> l:Wavl -> r:Wavl -> {v:Rank | WavlRankN v l r && v >= 0 }  -> {t:Wavl | EqRkN v t || RkDiffN v t 1 } @-}
--- merge :: a -> Tree a -> Tree a -> Int ->  Tree a
--- merge _ Nil Nil _ = nil
--- merge _ Nil r _  = r
--- merge _ l Nil _  = l
--- merge x l r n    = (balRDel y n l r')
---   where
---    (r', y)     = getMin r
+{-@ merge :: x:a -> l:Wavl -> r:Wavl -> {v:Rank | WavlRankN v l r && v >= 0 }  -> {t:Wavl | EqRkN v t || RkDiffN v t 1 } @-}
+merge :: a -> Tree a -> Tree a -> Int ->  Tree a
+merge _ Nil Nil _ = nil
+merge _ Nil r _  = r
+merge _ l Nil _  = l
+merge x l r n    = (balRDel y n l r')
+  where
+   (r', y)     = getMin r
 
--- -- get the inorder successor node 
--- {-@  getMin :: v:NEWavl -> ({t:Wavl | (EqRk v t) || (RkDiff v t 1) }, a) @-} 
--- getMin :: Tree a -> (Tree a, a)
--- getMin (Tree x 0 Nil Nil) = (nil, x)
--- getMin (Tree x 1 Nil r@(Tree _ _ _ _)) = (r, x)
--- getMin (Tree x n l@(Tree _ _ _ _) r@Nil) = ((balLDel x n l' r), x')
---   where
---     (l', x')             = getMin l
--- getMin (Tree x n l@(Tree _ _ _ _) r) = ((balLDel x n l' r), x')
---   where
---     (l', x')             = getMin l
+-- get the inorder successor node 
+{-@  getMin :: v:NEWavl -> ({t:Wavl | (EqRk v t) || (RkDiff v t 1) }, a) @-} 
+getMin :: Tree a -> (Tree a, a)
+getMin (Tree x 0 Nil Nil) = (nil, x)
+getMin (Tree x 1 Nil r@(Tree _ _ _ _)) = (r, x)
+getMin (Tree x n l@(Tree _ _ _ _) r@Nil) = ((balLDel x n l' r), x')
+  where
+    (l', x')             = getMin l
+getMin (Tree x n l@(Tree _ _ _ _) r) = ((balLDel x n l' r), x')
+  where
+    (l', x')             = getMin l
 
--- {-@ balLDel :: x:a -> n:NodeRank -> {l:Tick ({l':Wavl | Is3ChildN n l'}) | tcost l >= 0 } -> {r':MaybeWavlNode | Is2ChildN n r'} 
---           -> {t:Tick ({t':NEWavl | (rk t' == n || rk t' + 1 == n) && (potT2 t' + (tcost t - tcost l) <= (potT2 (Tree x n (tval l) r')) + 3) }) 
---           | tcost t >= 0 } @-} -- TODO: change to 2??
--- balLDel x 0 l@(Tick _ Nil) Nil  = RTick.step (tcost l) (pure (singleton x))
--- balLDel x 1 l@(Tick _ Nil) Nil  = RTick.step (tcost l) (pure (singleton x))
--- balLDel x n l r | n <= rk l' + 2 = t
---                  | n == rk l' + 3 && rk r + 2 == n = RTick.wmap demoteL t -- amort. cost 0
---                  | n == rk l' + 3 && rk r + 1 == n && rk (left r) + 2 == rk r && (rk (right r)) + 2 == rk r = RTick.wmap doubleDemoteL t --same 
---                  | n == rk l' + 3 && rk r + 1 == n && rk (right r) + 1 == rk r = RTick.wmap rotateLeftD t -- +1
---                  | n == rk l' + 3 && rk r + 1 == n && rk (right r) + 2 == rk r && rk (left r) + 1 == rk r = RTick.wmap rotateDoubleLeftD t -- +1
---                  | otherwise = RTick.step (tcost l) (pure (singleton x))
---                   where
---                     t = RTick.step (tcost l) (pure (Tree x n l' r))
---                     l' = tval l
+{-@ balLDel :: a -> {n:Rank | n >= 0 } -> {l:Wavl | Is3ChildN n l} -> {r:MaybeWavlNode | Is2ChildN n r} -> {t:NEWavl | (rk t == n || rk t + 1 == n) }  @-}
+balLDel :: a -> Int -> Tree a -> Tree a -> Tree a
+balLDel x 0 Nil Nil  = singleton x
+balLDel x 1 Nil Nil  = singleton x
+balLDel x n l r | n <= (rk l) + 2 = t 
+                | n == (rk l) + 3 && (rk r) + 2 == n = demoteL t 
+                | n == (rk l) + 3 && (rk r) + 1 == n && rk (left r) + 2 == (rk r) && (rk (right r)) + 2 == rk r = doubleDemoteL t
+                | n == (rk l) + 3 && (rk r) + 1 == n && rk (right r) + 1 == rk r = rotateLeftD t
+                | n == (rk l) + 3 && (rk r) + 1 == n && rk (right r) + 2 == rk r && rk (left r) + 1 == rk r = rotateDoubleLeftD t
+                  where
+                    t = Tree x n l r
 
-{-@ balRDel :: x:a -> n:NodeRank -> {l:MaybeWavlNode | Is2ChildN n l} -> {r:Tick ({r':Wavl | Is3ChildN n r'}) | tcost r >= 0 } -> {t: Tick ({t':NEWavl | (rk t' == n || rk t' + 1 == n) && (potT2 t' + (tcost t - tcost r) <= (potT2 (Tree x n l (tval r))) + 2) }) | tcost t >= 0 } @-}
-balRDel :: a -> Int -> Tree a -> Tick (Tree a) -> Tick (Tree a)
-balRDel x 0 Nil r@(Tick _ Nil) = RTick.step (tcost r) (pure (singleton x))
-balRDel x 1 Nil r@(Tick _ Nil) = RTick.step (tcost r) (pure (singleton x))
-balRDel x n l r  | n <  rk r' + 3 = t
-                  | n == rk r' + 3 && rk l + 2 == n = RTick.wmap demoteR t -- amort. cost 0
-                  | n == rk r' + 3 && rk l + 1 == n && rk (left l) + 2 == rk l && rk (right l) + 2 == rk l = RTick.wmap doubleDemoteR t -- same
-                  | n == rk r' + 3 && rk l + 1 == n && rk (left l) + 1 == rk l = RTick.wmap rotateRightD t -- +1
-                  | n == rk r' + 3 && rk l + 1 == n && rk (left l) + 2 == rk l && rk (right l) + 1 == rk l = RTick.wmap rotateDoubleRightD t -- +1
-                  -- | otherwise = t
+{-@ balRDel :: a -> n:Rank -> {l:MaybeWavlNode | Is2ChildN n l} -> {r:Wavl | Is3ChildN n r} -> {t:NEWavl | rk t == n || rk t + 1 == n } @-}
+balRDel :: a -> Int -> Tree a -> Tree a -> Tree a
+balRDel x 0 Nil Nil = singleton x
+balRDel x 1 Nil Nil = singleton x
+balRDel x n l r | n < (rk r + 3) = t
+                | n == (rk r + 3) && (rk l) + 2 == n = demoteR t
+                | n == (rk r + 3) && (rk l) + 1 == n && (rk (left l)) + 2 == rk l && (rk (right l)) + 2 == rk l = doubleDemoteR t
+                | n == (rk r + 3) && (rk l) + 1 == n && (rk (left l)) + 1 == rk l = rotateRightD t
+                | n == (rk r + 3) && (rk l) + 1 == n && (rk (left l)) + 2 == rk l && (rk (right l)) + 1 == rk l = rotateDoubleRightD t
                   where 
-                    t = RTick.step (tcost r) (pure (Tree x n l r')) 
-                    r' = tval r
-  
-{-@ demoteL :: s:Node3_2 -> {t:NEWavl | RkDiff s t 1 && potT2 s == potT2 t } @-}
+                    t = Tree x n l r
+
+-- potential analysis for deletion
+{-@ measure potT @-}
+{-@ potT :: t:Wavl -> {n:Int | potT2 t == n } @-}
+potT :: Tree a -> Int
+potT Nil      = 0
+potT t@(Tree _ n l r) 
+  | rk r + 2 == n && rk l + 2 == n = 1 + potT l + potT r        -- 2,2-Node
+  | otherwise = potT l + potT r                                -- 1,*-Nodes
+
+{-@ measure potT2 @-}
+{-@ potT2 :: t:AlmostWavl -> Int @-}
+potT2 :: Tree a -> Int 
+potT2 t@Nil = 0
+potT2 t@(Tree _ n l r)
+  | rk l + 3 == n && rk r + 2 == n    = 1 + potT l + potT r    -- 2,3-Node
+  | rk r + 3 == n && rk l + 2 == n    = 1 + potT l + potT r    -- 3,2-Node
+  | rk r + 2 == n && rk l + 2 == n    = 1 + potT l + potT r    -- 2,2-Node
+  | otherwise = potT l + potT r
+
+{-@ demoteL :: s:Node3_2 -> {t:NEWavl | RkDiff s t 1 && potT2 s == potT2 t + 1 } @-}
 demoteL :: Tree a -> Tree a
 demoteL (Tree a n l r) = Tree a (n - 1) l r
 
-{-@ doubleDemoteL :: {s:Node3_1 | IsNode2_2 (right s) } -> {t:NEWavl | RkDiff s t 1 && potT2 s + 1 == potT2 t } @-}
+{-@ doubleDemoteL :: {s:Node3_1 | IsNode2_2 (right s) } -> {t:NEWavl | RkDiff s t 1 && potT2 s == potT2 t + 1 } @-}
 doubleDemoteL :: Tree a -> Tree a
 doubleDemoteL (Tree x n l (Tree y m rl rr)) = (Tree x (n-1) l (Tree x (m-1) rl rr))
 
 {-@ rotateLeftD :: {s:Node3_1 | Child1 (rk (right s)) (right (right s)) 
           && (potT (left s)) + (potT (right s)) == potT2 s} 
-          -> {t:NEWavl | EqRk s t && (potT2 s - 1 == potT t || potT2 s == potT t || potT2 s + 1 == potT t) } @-}
+          -> {t:NEWavl | EqRk s t && (potT2 s == potT2 t || potT2 s + 1 == potT2 t) } @-} 
 rotateLeftD t@(Tree z n l@Nil (Tree y m rl@Nil rr)) = Tree y (m+1) (singleton z) rr
 rotateLeftD t@(Tree z n l (Tree y m rl rr)) = Tree y (m+1) (Tree z (n-1) l rl) rr 
 
 {-@ rotateDoubleLeftD :: {s:Node3_1 | IsNode1_2 (right s) 
           && (potT (left s)) + (potT (right s)) == potT2 s } 
-          -> {t:NEWavl | EqRk s t && (potT2 s == potT t || potT2 s + 1 == potT t ) } @-} 
+          -> {t:NEWavl | EqRk s t && potT2 s <= potT2 t } @-}
 rotateDoubleLeftD :: Tree a -> Tree a
 rotateDoubleLeftD (Tree z n l (Tree y m (Tree x o rll rlr) rr)) = Tree x n (Tree z (n-2) l rll) (Tree y (n-2) rlr rr)
 
-{-@ demoteR :: s:Node2_3 -> {t:NEWavl | RkDiff s t 1 && potT2 s == potT2 t } @-}
+{-@ demoteR :: s:Node2_3 -> {t:NEWavl | RkDiff s t 1 && potT2 s == potT2 t + 1 } @-}
 demoteR :: Tree a -> Tree a
 demoteR (Tree a n l r) = Tree a (n - 1) l r
 
 {-@ doubleDemoteR :: {s:Node1_3 | IsNode2_2 (left s) } 
-          -> {t:NEWavl | RkDiff s t 1 && potT2 s + 1 == potT2 t } @-}
+          -> {t:NEWavl | RkDiff s t 1 && potT2 s == potT2 t + 1 } @-}
 doubleDemoteR :: Tree a -> Tree a
 doubleDemoteR (Tree x n (Tree y m ll lr) r) = Tree x (n-1) (Tree y (m-1) ll lr) r 
 
+-- {-@ reflect rotateRightD @-}
 {-@ rotateRightD :: {s:Node1_3 | Child1 (rk (left s)) (left (left s))  
           && (potT (left s)) + (potT (right s)) == potT2 s} 
-          -> {t:NEWavl | EqRk s t && (potT2 s - 1 == potT t || potT2 s == potT t || potT2 s + 1 == potT t) } @-}
+          -> {t:NEWavl | EqRk s t && (potT2 s == potT2 t || potT2 s + 1 == potT2 t) } @-} 
 rotateRightD :: Tree a -> Tree a
 rotateRightD (Tree x n (Tree y m ll Nil) Nil) = Tree y (m+1) ll (singleton x)
 rotateRightD (Tree x n (Tree y m ll lr) r) = Tree y (m+1) ll (Tree x (n-1) lr r) 
 
-{-@ rotateDoubleRightD :: {s:Node1_3 | IsNode2_1 (left s) && (potT (left s)) + (potT (right s)) == potT2 s }
-          -> {t:NEWavl | EqRk s t && (potT2 s == potT t || potT2 s + 1 == potT t ) } @-}
+{-@ rotateDoubleRightD :: {s:Node1_3 | IsNode2_1 (left s) && (potT (right s)) + (potT  (left s)) == potT2 s }
+          -> {t:NEWavl | EqRk s t && potT2 s <= potT2 t } @-}
 rotateDoubleRightD :: Tree a -> Tree a
 rotateDoubleRightD (Tree x n (Tree y m ll (Tree z o lrl lrr)) r) = Tree z (o+2) (Tree y (m-1) ll lrl) (Tree x (n-2) lrr r)
 
@@ -489,13 +474,13 @@ rotateDoubleRightD (Tree x n (Tree y m ll (Tree z o lrl lrr)) r) = Tree z (o+2) 
 --             *** QED
 
 -- Test
--- main = do
---     mapM_ print [a,b,c,d,e,f,g]
---   where
---     a = singleton 5
---     b = insert 2 a
---     c = insert 3 b
---     d = insert 7 c
---     e = insert 10 d
---     f = delete 3 e
---     g = delete 10 f
+main = do
+    mapM_ print [a,b,c,d,e,f,g]
+  where
+    a = singleton 5
+    b = insert 2 a
+    c = insert 3 b
+    d = insert 7 c
+    e = insert 10 d
+    f = delete 3 e
+    g = delete 10 f


### PR DESCRIPTION
using a common potential function for both delete and insert makes it easier to determine how the potential changes when looking at both functions at the same time. 

The potential function description also changes in that regard s. t. we no longer look sseparately at the demote / promote steps for each function resp, but in a combined way i.e. saying that we look for the amortised cost of all rebalancing steps for delete and insert. 